### PR TITLE
Remove unused dart: imports

### DIFF
--- a/lib/src/numdart/linalg/matrix_operations/matrix_vander.dart
+++ b/lib/src/numdart/linalg/matrix_operations/matrix_vander.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import '../../../numdart/numdart.dart';
 
 /// Generate a Vandermonde matrix.

--- a/lib/src/scidart/fftpack/fft/fft.dart
+++ b/lib/src/scidart/fftpack/fft/fft.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'dart:math' as math;
 
 import 'package:scidart/src/numdart/numdart.dart';


### PR DESCRIPTION
Remove unused dart: import. A bug in the analyzer is causing it to not report this unused import currently. This PR is part of a cleanup to allow fixing the bug. See dart-lang/sdk#45028.