### PR TITLE
Enhance complex concat

### DIFF
--- a/lib/src/numdart/arrays_base/array_complex_operations/array_complex_concat.dart
+++ b/lib/src/numdart/arrays_base/array_complex_operations/array_complex_concat.dart
@@ -25,12 +25,5 @@ import '../array_complex.dart';
 /// */`
 /// ```
 ArrayComplex arrayComplexConcat(ArrayComplex a, ArrayComplex b) {
-  var c = ArrayComplex.empty();
-  for (var i = 0; i < a.length; i++) {
-    c.add(a[i]);
-  }
-  for (var i = 0; i < b.length; i++) {
-    c.add(b[i]);
-  }
-  return c;
+  return ArrayComplex(a + b);
 }

--- a/test/src/numdart/arrays_base/array_complex_operations/array_complex_concat_test.dart
+++ b/test/src/numdart/arrays_base/array_complex_operations/array_complex_concat_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scidart/numdart.dart';
+
+void main() {
+  test('complex concat duration', () async {
+    final sr = 48000;
+    final x = arrayToComplexArray(ones(sr * 5));
+    final s = Stopwatch();
+    s.start();
+    final y = arrayComplexConcat(x, x);
+    final elapsed = s.elapsedMilliseconds / 1000; // elapsed seconds
+    expect(elapsed, lessThan(1));
+    expect(y.length, sr * 10);
+  });
+
+  test('complex concat values', () async {
+    final sr = 1;
+    final x1 = arrayToComplexArray(ones(sr * 5));
+    final x2 = arrayToComplexArray(zeros(sr * 5));
+    final y = arrayComplexConcat(x1, x2);
+    expect(y.length, 10);
+    expect(
+        y,
+        ArrayComplex([
+          Complex(real: 1),
+          Complex(real: 1),
+          Complex(real: 1),
+          Complex(real: 1),
+          Complex(real: 1),
+          Complex(real: 0),
+          Complex(real: 0),
+          Complex(real: 0),
+          Complex(real: 0),
+          Complex(real: 0)
+        ]));
+  });
+}


### PR DESCRIPTION
The complex concat function is too slow because it loops with an .add function which is not performatic.

This PR is related to the following issue:
- https://github.com/scidart/scidart/issues/49