### PR TITLE
Fix firwin bandpass highpass

### DIFF
--- a/lib/src/scidart/signal/fir/firwin.dart
+++ b/lib/src/scidart/signal/fir/firwin.dart
@@ -118,21 +118,21 @@ dynamic firwin(int numtaps, Array cutoff,
               'cutoff must have at least two elements if pass_zero=="bandstop", got $cutoff');
         }
         pass_zero = true;
-      } else if (pass_zero == 'bandpass' || pass_zero == 'highpass') {
-        if (pass_zero == 'highpass') {
-          if (cutoff.length != 1) {
-            throw FormatException(
-                'cutoff must have one element if pass_zero=="highpass", got ${cutoff.length}');
-          }
-        } else if (cutoff.length <= 1) {
+      } 
+    } else if (pass_zero == 'bandpass' || pass_zero == 'highpass') {
+      if (pass_zero == 'highpass') {
+        if (cutoff.length != 1) {
           throw FormatException(
-              'cutoff must have at least two elements if pass_zero=="bandpass", got $cutoff');
+              'cutoff must have one element if pass_zero=="highpass", got ${cutoff.length}');
         }
-        pass_zero = false;
-      } else {
+      } else if (cutoff.length <= 1) {
         throw FormatException(
-            'pass_zero must be True, False, "bandpass", "lowpass", "highpass", or "bandstop", got $pass_zero');
+            'cutoff must have at least two elements if pass_zero=="bandpass", got $cutoff');
       }
+      pass_zero = false;
+    } else {
+      throw FormatException(
+          'pass_zero must be True, False, "bandpass", "lowpass", "highpass", or "bandstop", got $pass_zero');
     }
   }
 

--- a/lib/src/scidart/signal/fir/firwin.dart
+++ b/lib/src/scidart/signal/fir/firwin.dart
@@ -124,12 +124,12 @@ dynamic firwin(int numtaps, Array cutoff,
         if (cutoff.length != 1) {
           throw FormatException(
               'cutoff must have one element if pass_zero=="highpass", got ${cutoff.length}');
-        }
-      } else if (cutoff.length <= 1) {
+        } else if (cutoff.length <= 1) {
         throw FormatException(
             'cutoff must have at least two elements if pass_zero=="bandpass", got $cutoff');
+        }
+        pass_zero = false;
       }
-      pass_zero = false;
     } else {
       throw FormatException(
           'pass_zero must be True, False, "bandpass", "lowpass", "highpass", or "bandstop", got $pass_zero');


### PR DESCRIPTION
There is a misalignment with the braces for the guard clause which checks for the possible values of pass_zero. 

Currently the logic looks like this:
```
if (pass_zero == 'bandstop' || pass_zero == 'lowpass') {
...
      else if (pass_zero == 'bandpass' || pass_zero == 'highpass') {
...
}}
```

The intended logic should be:
if (pass_zero == 'bandstop' || pass_zero == 'lowpass') {
...
} else if (pass_zero == 'bandpass' || pass_zero == 'highpass') {
...
}
```

