### PR TITLE
fix: Sort array before median calculation for issue #59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2-dev.13
+
+- Sort array before median calculation (#59 Closed)
+
 ## 0.0.2-dev.12
 
 - Add operation created for Array2d (#48 Closed)

--- a/lib/src/numdart/statistic/median.dart
+++ b/lib/src/numdart/statistic/median.dart
@@ -13,6 +13,7 @@ import 'package:scidart/src/numdart/arrays_base/array.dart';
 /// */
 /// ```
 double median(Array a) {
+  a.sort();
   var middle = a.length ~/ 2;
   if (a.length % 2 == 1) {
     return a[middle];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scidart
 description: Cross-platform scientific library for Dart. The main goal of SciDart is run where Dart can run, in other words, run on Flutter, Dart CLI, Dart web, etc.
-version: 0.0.2-dev.12
+version: 0.0.2-dev.13
 repository: https://github.com/scidart/scidart
 homepage: https://scidart.org/
 

--- a/test/numdart/statistic/median_test.dart
+++ b/test/numdart/statistic/median_test.dart
@@ -12,4 +12,15 @@ void main() {
 
     expect(n, nExp);
   });
+
+  test('median unsorted', () {
+    var a = Array([3.0, 1.0, 2.0]);
+    var n = median(a);
+
+    print(n);
+
+    var nExp = 2.0;
+
+    expect(n, nExp);
+  });
 }


### PR DESCRIPTION
Ensures the array is sorted prior to finding the median value to address the bug described in #59 "median calculation does not sort before getting mid value". This ensures correct median computation for all input arrays.